### PR TITLE
Fixmicroenv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xCell
 Type: Package
 Title: Cell type enrichment analysis
-Version: 1.1.0
+Version: 1.1.1
 Author: person(“Dvir”, “Aran”, email = “dvir.aran@ucsf.edu”,role = c("aut", "cre"))
 Maintainer: Dvir Aran <dvir.aran@ucsf.edu>
 Description: Tissues are a complex milieu consisting of numerous cell types. 

--- a/R/xCell.R
+++ b/R/xCell.R
@@ -178,13 +178,10 @@ spillOver <- function(transformedScores, K, alpha = 1, file.name = NULL) {
 #'
 #' @return the microenvironment scores
 microenvironmentScores <- function(adjustedScores) {
-  mygrep <- function(x, target){
-      return(grep(x, target))
-  }
   imm.sig <- c('B-cells','CD4+ T-cells','CD8+ T-cells','DC','Eosinophils','Macrophages','Monocytes','Mast cells','Neutrophils','NK cells')
   strom.sig <- c('Adipocytes','Endothelial cells','Fibroblasts')
-  imm.ix <- unlist(sapply(sub("+", "\\\\+", imm.sig), mygrep, target=rownames(adjustedScores))
-  strom.ix <- unlist(sapply(sub("+", "\\\\+", strom.sig), mygrep, target=rownames(adjustedScores))
+  imm.ix <- unlist(sapply(sub("+", "\\\\+", imm.sig), grep, x=rownames(adjustedScores)))
+  strom.ix <- unlist(sapply(sub("+", "\\\\+", strom.sig), grep, x=rownames(adjustedScores)))
   if (length(imm.ix)){
       ImmuneScore <- apply(adjustedScores[imm.ix,],2,sum)/1.5
   } else {

--- a/R/xCell.R
+++ b/R/xCell.R
@@ -178,10 +178,13 @@ spillOver <- function(transformedScores, K, alpha = 1, file.name = NULL) {
 #'
 #' @return the microenvironment scores
 microenvironmentScores <- function(adjustedScores) {
+  mygrep <- function(x, target){
+      return(grep(x, target))
+  }
   imm.sig <- c('B-cells','CD4+ T-cells','CD8+ T-cells','DC','Eosinophils','Macrophages','Monocytes','Mast cells','Neutrophils','NK cells')
   strom.sig <- c('Adipocytes','Endothelial cells','Fibroblasts')
-  imm.ix <- grep(sub("+", "\\\\+", imm.sig), rownames(adjustedScores))
-  strom.ix <- grep(sub("+", "\\\\+", strom.sig), rownames(adjustedScores))
+  imm.ix <- unlist(sapply(sub("+", "\\\\+", imm.sig), mygrep, target=rownames(adjustedScores))
+  strom.ix <- unlist(sapply(sub("+", "\\\\+", strom.sig), mygrep, target=rownames(adjustedScores))
   if (length(imm.ix)){
       ImmuneScore <- apply(adjustedScores[imm.ix,],2,sum)/1.5
   } else {

--- a/R/xCell.R
+++ b/R/xCell.R
@@ -135,7 +135,7 @@ transformScores <- function(scores, fit.vals, scale=TRUE,
     fit.vals[A,3] = 1
   }
 
-  tscores <- (tscores^fit.vals[A,2])/(fit.vals[A,3]*2)
+  tscores <- (tscores^fit.vals[A,2])/as.numeric(fit.vals[A,3]*2)
 
   if (!is.null(fn)) {
     write.table(format(tscores, digits = 4), file = fn, sep = "\t",
@@ -178,8 +178,20 @@ spillOver <- function(transformedScores, K, alpha = 1, file.name = NULL) {
 #'
 #' @return the microenvironment scores
 microenvironmentScores <- function(adjustedScores) {
-  ImmuneScore = apply(adjustedScores[c('B-cells','CD4+ T-cells','CD8+ T-cells','DC','Eosinophils','Macrophages','Monocytes','Mast cells','Neutrophils','NK cells'),],2,sum)/1.5
-  StromaScore = apply(adjustedScores[c('Adipocytes','Endothelial cells','Fibroblasts'),],2,sum)/2
+  imm.sig <- c('B-cells','CD4+ T-cells','CD8+ T-cells','DC','Eosinophils','Macrophages','Monocytes','Mast cells','Neutrophils','NK cells')
+  strom.sig <- c('Adipocytes','Endothelial cells','Fibroblasts')
+  imm.ix <- grep(sub("+", "\\\\+", imm.sig), rownames(adjustedScores))
+  strom.ix <- grep(sub("+", "\\\\+", strom.sig), rownames(adjustedScores))
+  if (length(imm.ix)){
+      ImmuneScore <- apply(adjustedScores[imm.ix,],2,sum)/1.5
+  } else {
+      ImmuneScore <- rep(0, ncol(adjustedScores))
+  }
+  if (length(imm.ix)){
+      StromaScore <- apply(adjustedScores[strom.ix,],2,sum)/2
+  } else {
+      StromaScore <- rep(0, ncol(adjustedScores))
+  }
   MicroenvironmentScore = ImmuneScore+StromaScore
   adjustedScores = rbind(adjustedScores,ImmuneScore,StromaScore,MicroenvironmentScore)
 }


### PR DESCRIPTION
[major fix] When using a subset of cell types <microenvironmentScores> function fail to execute because the names do not match. Solved using a dynamic search of names in the input data.

[minor fix] function <transformScores> fails when subsetting cell types because of _non-conformable arrays_ error. Solved transforming the denominator with the right dimensions.